### PR TITLE
main 브랜치를 gh-pages 브랜치로 머지

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,23 @@
+name: Jekyll site CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the site in the jekyll/builder container
+      run: |
+        docker run \
+        -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
+        jekyll/builder:latest /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@4.1.5
+      with:
+        branch: gh-pages
+        folder: _site

--- a/_posts/2025-04-01-my-news-2025.md
+++ b/_posts/2025-04-01-my-news-2025.md
@@ -1,0 +1,6 @@
+---
+layout: post
+title: "2025년 나의 글"
+date: 2025-04-01 12:00:00 -0000
+categories: news
+---


### PR DESCRIPTION
GitHub Pages 배포를 위해 main 브랜치의 최신 변경사항을 gh-pages 브랜치로
머지합니다.